### PR TITLE
Improve blog rendering

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,9 +6,11 @@
     <title>sanscar - Blog</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.15.3/katex.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.15.3/katex.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.15.3/contrib/auto-render.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.2/marked.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
     <style>
         body {
             font-family: 'MS Sans Serif', Arial, sans-serif;
@@ -101,16 +103,13 @@
         const blogContainer = document.getElementById('blog-container');
         const errorMessage = document.getElementById('error-message');
 
-        // Configure marked to use KaTeX for LaTeX rendering
+        // Configure marked and highlight.js
         marked.setOptions({
             highlight: function(code, lang) {
-                if (lang === 'math') {
-                    return katex.renderToString(code, {
-                        throwOnError: false,
-                        displayMode: true
-                    });
+                if (lang && hljs.getLanguage(lang)) {
+                    return hljs.highlight(code, { language: lang }).value;
                 }
-                return code;
+                return hljs.highlightAuto(code).value;
             }
         });
 
@@ -126,17 +125,28 @@
                 if (posts.length === 0) {
                     throw new Error('No blog posts found in the JSON file.');
                 }
+                return Promise.all(posts.map(async post => {
+                    const mdRes = await fetch(post.file);
+                    if (!mdRes.ok) {
+                        throw new Error(`Failed to load ${post.file}`);
+                    }
+                    const md = await mdRes.text();
+                    return {...post, md};
+                }));
+            })
+            .then(posts => {
                 posts.forEach(post => {
                     const postDiv = document.createElement('div');
                     postDiv.classList.add('blog-post');
                     postDiv.innerHTML = `
                         <div class="blog-title">${post.title}</div>
                         <div class="blog-date">${post.date}</div>
-                        <div class="blog-content">${marked.parse(post.content)}</div>
+                        <div class="blog-content">${marked.parse(post.md)}</div>
                     `;
                     blogContainer.appendChild(postDiv);
                 });
-                // Render LaTeX after adding blog posts
+
+                hljs.highlightAll();
                 renderMathInElement(document.body, {
                     delimiters: [
                         {left: "$$", right: "$$", display: true},

--- a/blog.json
+++ b/blog.json
@@ -2,6 +2,6 @@
   {
     "title": "Basics of Distillation",
     "date": "2024-08-01",
-    "content": "# Basics of Distillation\n\n- A large trained model + a good regularizer\n- Distillation - transfer its knowledge to the small model\n- Large model assigns probabilities to the wrong class, less in value but still assigns but it tells us about how they generalize\n- Objective function (training) should reflect true objective, rather trained to optimize performance\n- Real objective = generalize to new data\n\nMore details to be added..."
+    "file": "posts/basics-of-distillation/README.md"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -6,8 +6,11 @@
     <title>sanscar</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.15.3/katex.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.15.3/katex.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.15.3/contrib/auto-render.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.2/marked.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
     <style>
         body {
             font-family: 'MS Sans Serif', Arial, sans-serif;
@@ -214,6 +217,16 @@
         const blogContainer = document.getElementById('blog-container');
         const errorMessage = document.getElementById('error-message');
 
+        // Configure marked and highlight.js for posts
+        marked.setOptions({
+            highlight: function(code, lang) {
+                if (lang && hljs.getLanguage(lang)) {
+                    return hljs.highlight(code, { language: lang }).value;
+                }
+                return hljs.highlightAuto(code).value;
+            }
+        });
+
         // Fetch blog posts from blog.json
         fetch('blog.json')
             .then(response => {
@@ -226,20 +239,35 @@
                 if (posts.length === 0) {
                     throw new Error('No blog posts found in the JSON file.');
                 }
+                return Promise.all(posts.map(async post => {
+                    const mdRes = await fetch(post.file);
+                    if (!mdRes.ok) {
+                        throw new Error(`Failed to load ${post.file}`);
+                    }
+                    const md = await mdRes.text();
+                    return {...post, md};
+                }));
+            })
+            .then(posts => {
                 posts.forEach(post => {
+                    const html = marked.parse(post.md);
+                    const tmp = document.createElement('div');
+                    tmp.innerHTML = html;
+                    const textContent = tmp.textContent || tmp.innerText || '';
+                    const truncatedContent = textContent.length > 150 ? textContent.substring(0, 150) + '...' : textContent;
+
                     const postDiv = document.createElement('div');
                     postDiv.classList.add('blog-post');
-                    const truncatedContent = post.content.length > 150 ? post.content.substring(0, 150) + '...' : post.content;
                     postDiv.innerHTML = `
                         <div class="blog-title">${post.title}</div>
                         <div class="blog-date">${post.date}</div>
                         <div class="blog-content">${truncatedContent}</div>
-                        ${post.content.length > 150 ? '<button class="blog-expand-button">Read More</button>' : ''}
-                        <div class="blog-full-content hidden">${post.content}</div>
+                        ${textContent.length > 150 ? '<button class="blog-expand-button">Read More</button>' : ''}
+                        <div class="blog-full-content hidden">${html}</div>
                     `;
                     blogContainer.appendChild(postDiv);
 
-                    if (post.content.length > 150) {
+                    if (textContent.length > 150) {
                         const expandButton = postDiv.querySelector('.blog-expand-button');
                         const fullContent = postDiv.querySelector('.blog-full-content');
                         expandButton.addEventListener('click', () => {
@@ -247,14 +275,16 @@
                             expandButton.textContent = fullContent.classList.contains('hidden') ? 'Read More' : 'Show Less';
                         });
                     }
+
+                    renderMathInElement(postDiv, {
+                        delimiters: [
+                            {left: "$$", right: "$$", display: true},
+                            {left: "$", right: "$", display: false}
+                        ]
+                    });
                 });
-                // Render LaTeX after adding blog posts
-                renderMathInElement(document.body, {
-                    delimiters: [
-                        {left: "$$", right: "$$", display: true},
-                        {left: "$", right: "$", display: false}
-                    ]
-                });
+
+                hljs.highlightAll();
             })
             .catch(error => {
                 console.error('Error loading blog posts:', error);

--- a/posts/basics-of-distillation/README.md
+++ b/posts/basics-of-distillation/README.md
@@ -1,0 +1,18 @@
+# Basics of Distillation
+
+Distillation transfers the knowledge from a larger model to a smaller one while keeping the smaller model well regularized.
+
+The large model assigns probabilities even to wrong classes. This behaviour gives clues about its generalization.
+
+Training objectives should reflect the real goal of good generalization rather than just immediate performance.
+
+$$
+L = -\sum_i p_i \log q_i
+$$
+
+```python
+def distill(student, teacher):
+    return teacher.predict(student.inputs)
+```
+
+More details to be added...


### PR DESCRIPTION
## Summary
- store blog posts as standalone Markdown files
- update `blog.json` to reference the Markdown source
- render blog posts from Markdown with proper syntax highlighting and LaTeX support in `blog.html` and `index.html`
- add first post in `posts/basics-of-distillation/README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c10c7380c8333934e79396730180b