### PR TITLE
Fix latex rendering on expanding blog posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,6 +273,18 @@
                         expandButton.addEventListener('click', () => {
                             fullContent.classList.toggle('hidden');
                             expandButton.textContent = fullContent.classList.contains('hidden') ? 'Read More' : 'Show Less';
+
+                            if (!fullContent.classList.contains('hidden')) {
+                                renderMathInElement(fullContent, {
+                                    delimiters: [
+                                        {left: "$$", right: "$$", display: true},
+                                        {left: "$", right: "$", display: false}
+                                    ]
+                                });
+                                fullContent.querySelectorAll('pre code').forEach(block => {
+                                    hljs.highlightElement(block);
+                                });
+                            }
                         });
                     }
 


### PR DESCRIPTION
## Summary
- ensure KaTeX and code highlighting are applied when a post is expanded

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_686c207146788333a93be4c8ab299b96